### PR TITLE
Add the ability for users who want to customize the way to do the assertion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 gradle.properties
 moscow.i*
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 build/
 gradle.properties
+moscow.i*

--- a/README.md
+++ b/README.md
@@ -302,3 +302,25 @@ Because we need to build requests from Moco contracts, some matchers such as `xp
   ```
   ./gradlew clean build
   ```
+
+## Contribute
+
+To disable the task `signArchives`, execute
+
+```sh
+$ gradle build -x signArchives
+```
+
+and to run all the tests, you should start `moco` server:
+
+```sh
+./startMoco
+```
+
+it will download the moco-standalone, and run the moco server in port `12306`.
+
+If you are using `IntelliJ Idea` as IDE,
+
+```sh
+$ gradle build idea -x signArchives
+```

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
+apply plugin: 'idea'
+
 sourceCompatibility = 1.7
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testCompile 'org.springframework:spring-test:4.2.4.RELEASE'
     testRuntime 'ch.qos.logback:logback-classic:1.1.3'
+    testCompile 'com.jayway.jsonpath:json-path:2.2.0'
 }
 
 task javadocJar(type: Jar) {

--- a/src/main/java/com/github/macdao/moscow/AbstractContractAssertion.java
+++ b/src/main/java/com/github/macdao/moscow/AbstractContractAssertion.java
@@ -1,0 +1,12 @@
+package com.github.macdao.moscow;
+
+import com.github.macdao.moscow.http.RestResponse;
+import com.github.macdao.moscow.model.Contract;
+import com.github.macdao.moscow.model.ContractResponse;
+
+public abstract class AbstractContractAssertion {
+    public abstract void assertContract(RestResponse responseEntity, Contract contract);
+    public abstract void assertStatusCode(RestResponse responseEntity, ContractResponse contractResponse);
+    public abstract void assertHeaders(RestResponse responseEntity, ContractResponse contractResponse);
+    public abstract void assertBody(RestResponse responseEntity, Contract contract);
+}

--- a/src/main/java/com/github/macdao/moscow/DefaultContractAssertion.java
+++ b/src/main/java/com/github/macdao/moscow/DefaultContractAssertion.java
@@ -89,6 +89,16 @@ public class DefaultContractAssertion extends AbstractContractAssertion{
         return variables;
     }
 
+    public DefaultContractAssertion variable(String key, String value) {
+        this.variables.put(key, value);
+        return this;
+    }
+
+    public DefaultContractAssertion variables(Map<String, String> map) {
+        this.variables.putAll(map);
+        return this;
+    }
+
     private void assertContract(Contract contract) {
         final RestResponse responseEntity = execute(contract);
 

--- a/src/main/java/com/github/macdao/moscow/DefaultContractAssertion.java
+++ b/src/main/java/com/github/macdao/moscow/DefaultContractAssertion.java
@@ -34,7 +34,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ContractAssertion {
+public class DefaultContractAssertion extends AbstractContractAssertion{
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final List<Contract> contracts;
     private final Map<String, String> variables = new HashMap<>();
@@ -47,37 +47,37 @@ public class ContractAssertion {
     private boolean necessity = false;
     private int executionTimeout = 0;
 
-    public ContractAssertion(List<Contract> contracts) {
+    public DefaultContractAssertion(List<Contract> contracts) {
         Preconditions.checkArgument(!contracts.isEmpty(), "Given contract list is empty!");
         this.contracts = contracts;
     }
 
-    public ContractAssertion setRestExecutor(RestExecutor restExecutor) {
+    public DefaultContractAssertion setRestExecutor(RestExecutor restExecutor) {
         this.restExecutor = restExecutor;
         return this;
     }
 
-    public ContractAssertion setScheme(String scheme) {
+    public DefaultContractAssertion setScheme(String scheme) {
         this.scheme = scheme;
         return this;
     }
 
-    public ContractAssertion setPort(int port) {
+    public DefaultContractAssertion setPort(int port) {
         this.port = port;
         return this;
     }
 
-    public ContractAssertion setHost(String host) {
+    public DefaultContractAssertion setHost(String host) {
         this.host = host;
         return this;
     }
 
-    public ContractAssertion setNecessity(boolean necessity) {
+    public DefaultContractAssertion setNecessity(boolean necessity) {
         this.necessity = necessity;
         return this;
     }
 
-    public ContractAssertion setExecutionTimeout(int executionTimeout) {
+    public DefaultContractAssertion setExecutionTimeout(int executionTimeout) {
         this.executionTimeout = executionTimeout;
         return this;
     }
@@ -99,18 +99,21 @@ public class ContractAssertion {
         assertContract(responseEntity, contract);
     }
 
-    private void assertContract(RestResponse responseEntity, Contract contract) {
+    @Override
+    public void assertContract(RestResponse responseEntity, Contract contract) {
         final ContractResponse contractResponse = contract.getResponse();
         assertStatusCode(responseEntity, contractResponse);
         assertHeaders(responseEntity, contractResponse);
         assertBody(responseEntity, contract);
     }
 
-    private void assertStatusCode(RestResponse responseEntity, ContractResponse contractResponse) {
+    @Override
+    public void assertStatusCode(RestResponse responseEntity, ContractResponse contractResponse) {
         assertThat(responseEntity.getStatusCode(), is(contractResponse.getStatus()));
     }
 
-    private void assertHeaders(RestResponse responseEntity, ContractResponse contractResponse) {
+    @Override
+    public void assertHeaders(RestResponse responseEntity, ContractResponse contractResponse) {
         for (Map.Entry<String, String> entry : contractResponse.getHeaders().entrySet()) {
             final String actualHeader = responseEntity.getHeaders().get(entry.getKey());
             final String expectedPattern = entry.getValue().replace("{port}", String.valueOf(port))
@@ -119,7 +122,8 @@ public class ContractAssertion {
         }
     }
 
-    private void assertBody(RestResponse responseEntity, Contract contract) {
+    @Override
+    public void assertBody(RestResponse responseEntity, Contract contract) {
         final ContractResponse contractResponse = contract.getResponse();
         final String actualBody = responseEntity.getBody();
 

--- a/src/test/java/com/github/macdao/moscow/CustomizeContractAssertionTest.java
+++ b/src/test/java/com/github/macdao/moscow/CustomizeContractAssertionTest.java
@@ -1,0 +1,58 @@
+package com.github.macdao.moscow;
+
+import com.github.macdao.moscow.http.RestResponse;
+import com.github.macdao.moscow.http.RestTemplateExecutor;
+import com.github.macdao.moscow.json.JsonConverter;
+import com.github.macdao.moscow.json.JsonConverterFactory;
+import com.github.macdao.moscow.model.Contract;
+import com.github.macdao.moscow.model.ContractResponse;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class CustomizeContractAssertionTest {
+    private static final ContractContainer contractContainer =
+            new ContractContainer(Paths.get("src/test/resources/contracts"));
+
+    @Rule
+    public final TestName name = new TestName();
+
+    @Test
+    public void should_return_complicated_json_payload() throws Exception {
+        new MyContractAssertion(contractContainer.findContracts(name.getMethodName()))
+                .setPort(12306)
+                .setRestExecutor(new RestTemplateExecutor())
+                .assertContract();
+    }
+
+}
+
+class MyContractAssertion extends DefaultContractAssertion {
+
+    public MyContractAssertion(List<Contract> contracts) {
+        super(contracts);
+    }
+
+    @Override
+    public void assertBody(RestResponse responseEntity, Contract contract) {
+        String body = responseEntity.getBody();
+
+        ContractResponse contractResponse = contract.getResponse();
+        JsonConverter jsonConverter = JsonConverterFactory.getJsonConverter();
+
+        List<String> items = JsonPath.read(body, "$.items");
+        assert jsonConverter != null;
+
+        String serializedContract = jsonConverter.serialize(contractResponse.getJson());
+        List<String> items2 = JsonPath.read(serializedContract, "$.items");
+
+        assertThat(items, is(items2));
+    }
+}

--- a/src/test/java/com/github/macdao/moscow/DefaultContractAssertionAdvancedTest.java
+++ b/src/test/java/com/github/macdao/moscow/DefaultContractAssertionAdvancedTest.java
@@ -1,0 +1,47 @@
+package com.github.macdao.moscow;
+
+import com.github.macdao.moscow.http.RestTemplateExecutor;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultContractAssertionAdvancedTest {
+    private static final ContractContainer contractContainer =
+            new ContractContainer(Paths.get("src/test/resources/contracts"));
+
+    @Rule
+    public final TestName name = new TestName();
+
+
+    @Test
+    @Ignore("Since we are testing against the moco server, payload wont be correct")
+    public void should_return_replaced_contract() throws Exception {
+        new DefaultContractAssertion(contractContainer.findContracts(name.getMethodName()))
+                .setPort(12306)
+                .variable("name", "juntao")
+                .variable("email", "juntao.qiu@gmail.com")
+                .setRestExecutor(new RestTemplateExecutor())
+                .assertContract();
+    }
+
+    @Test
+    @Ignore("Since we are testing against the moco server, payload wont be correct")
+    public void should_return_replaced_contract2() throws Exception {
+        Map<String, String> context = new HashMap<>();
+
+        context.put("name", "juntao");
+        context.put("host", "localhost");
+        context.put("port", "12306");
+        context.put("email", "juntao.qiu@gmail.com");
+
+        new DefaultContractAssertion(contractContainer.findContracts(name.getMethodName()))
+                .variables(context)
+                .setRestExecutor(new RestTemplateExecutor())
+                .assertContract();
+    }
+}

--- a/src/test/java/com/github/macdao/moscow/DefaultContractAssertionTest.java
+++ b/src/test/java/com/github/macdao/moscow/DefaultContractAssertionTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
-public class ContractAssertionTest {
+public class DefaultContractAssertionTest {
     private static final ContractContainer contractContainer = new ContractContainer(Paths.get("src/test/resources/contracts"));
 
     @Parameterized.Parameters
@@ -91,7 +91,7 @@ public class ContractAssertionTest {
 
     @Test
     public void request_text_bar3_should_response_json() throws Exception {
-        new ContractAssertion(contractContainer.findContracts(methodName()))
+        new DefaultContractAssertion(contractContainer.findContracts(methodName()))
                 .setScheme("http")
                 .setHost("127.0.0.1")
                 .setPort(12306)
@@ -100,7 +100,7 @@ public class ContractAssertionTest {
 
     @Test
     public void request_text_bar4_should_response_foo() throws Exception {
-        new ContractAssertion(contractContainer.findContracts(methodName()))
+        new DefaultContractAssertion(contractContainer.findContracts(methodName()))
                 .setPort(12306)
                 .setNecessity(true)
                 .assertContract();
@@ -108,7 +108,7 @@ public class ContractAssertionTest {
 
     @Test(expected = ExecutionTimeoutException.class)
     public void request_text_bar5_should_response_timeout() throws Exception {
-        new ContractAssertion(contractContainer.findContracts(methodName()))
+        new DefaultContractAssertion(contractContainer.findContracts(methodName()))
                 .setPort(12306)
                 .setExecutionTimeout(100)
                 .assertContract();
@@ -151,7 +151,7 @@ public class ContractAssertionTest {
     }
 
     private Map<String, String> assertContract() {
-        return new ContractAssertion(contractContainer.findContracts(methodName()))
+        return new DefaultContractAssertion(contractContainer.findContracts(methodName()))
                 .setPort(12306)
                 .setRestExecutor(restExecutor)
                 .assertContract();

--- a/src/test/java/com/github/macdao/moscow/spring/ApiTestBase.java
+++ b/src/test/java/com/github/macdao/moscow/spring/ApiTestBase.java
@@ -1,6 +1,6 @@
 package com.github.macdao.moscow.spring;
 
-import com.github.macdao.moscow.ContractAssertion;
+import com.github.macdao.moscow.DefaultContractAssertion;
 import com.github.macdao.moscow.ContractContainer;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -28,7 +28,7 @@ public abstract class ApiTestBase {
     }
 
     protected Map<String, String> assertContract(String description) {
-        return new ContractAssertion(container.findContracts(description))
+        return new DefaultContractAssertion(container.findContracts(description))
                 .setPort(port)
                 .setExecutionTimeout(200)
                 .assertContract();

--- a/src/test/resources/contracts/index.json
+++ b/src/test/resources/contracts/index.json
@@ -13,5 +13,8 @@
   },
   {
     "include": "file.json"
+  },
+  {
+    "include": "json-payload.json"
   }
 ]

--- a/src/test/resources/contracts/index.json
+++ b/src/test/resources/contracts/index.json
@@ -16,5 +16,8 @@
   },
   {
     "include": "json-payload.json"
+  },
+  {
+    "include": "with-variables.json"
   }
 ]

--- a/src/test/resources/contracts/json-payload.json
+++ b/src/test/resources/contracts/json-payload.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "should_return_complicated_json_payload",
+    "request": {
+      "method": "GET",
+      "uri": "/payload/1"
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "application/json;charset=UTF-8"
+      },
+      "json": {
+        "items": ["one", "two", "three"],
+        "_links": {
+          "self": "http://localhost:9999/payload/1"
+        }
+      }
+    }
+  }
+]

--- a/src/test/resources/contracts/with-variables.json
+++ b/src/test/resources/contracts/with-variables.json
@@ -1,0 +1,24 @@
+[
+  {
+    "description": "should_return_replaced_contract",
+    "request": {
+      "method": "GET",
+      "uri": "/variables/1"
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "application/json;charset=UTF-8"
+      },
+      "json": {
+        "items": ["one", "two", "three"],
+        "author": {
+          "name": "{name}",
+          "email": "{email}"
+        },
+        "_links": {
+          "self": "http://localhost:9999/payload/1"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
Add a new abstraction `AbstractContractAssertion`, and move the `ContractAssertion` into `DefaultContractAssertion`. 

Details you can take a look at the code.

```java
class MyContractAssertion extends DefaultContractAssertion {

    public MyContractAssertion(List<Contract> contracts) {
        super(contracts);
    }

    @Override
    public void assertBody(RestResponse responseEntity, Contract contract) {
        String body = responseEntity.getBody();

        ContractResponse contractResponse = contract.getResponse();
        JsonConverter jsonConverter = JsonConverterFactory.getJsonConverter();

        List<String> items = JsonPath.read(body, "$.items");
        assert jsonConverter != null;

        String serializedContract = jsonConverter.serialize(contractResponse.getJson());
        List<String> items2 = JsonPath.read(serializedContract, "$.items");

        assertThat(items, is(items2));
    }
}
```